### PR TITLE
Check readURL return value

### DIFF
--- a/src/skinsrestorer/shared/utils/MojangAPI.java
+++ b/src/skinsrestorer/shared/utils/MojangAPI.java
@@ -42,7 +42,7 @@ public class MojangAPI {
 	public static Profile getProfile(String name) throws MalformedURLException, SkinFetchFailedException {
 		String output = readURL(new URL(uuidurl + name));
 
-		if (output.isEmpty()) 
+		if (output == null || output.isEmpty()) 
 			throw new SkinFetchUtils.SkinFetchFailedException(Reason.NO_PREMIUM_PLAYER);
 		
 		return new Profile(output.substring(7, 39), name);


### PR DESCRIPTION
From my `debug.txt`:

```
Java version: 1.8.0_92
Bukkit version: 1.9-R0.1-SNAPSHOT
SkinsRestoerer version: 11.6

Plugin list: AutoSaveWorld (4.14.2), TreeAssist (5.10.1), MultiWorld (5.2.8), SkinsRestorer (11.6), Log (1.4), Essentials (2.0.1-b342), EssentialsSpawn (2.0.1-b342), LoginSecurity (2.0.14), 

Property output from MojangAPI (Notch) : 
=========================================
java.lang.NullPointerException
        at skinsrestorer.shared.utils.MojangAPI.getProfile(MojangAPI.java:45)
        at skinsrestorer.bukkit.SkinsRestorer.onEnable(SkinsRestorer.java:174)
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:292)
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:340)
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:405)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.loadPlugin(CraftServer.java:361)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.enablePlugins(CraftServer.java:321)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.reload(CraftServer.java:744)
        at org.bukkit.Bukkit.reload(Bukkit.java:539)
        at org.bukkit.command.defaults.ReloadCommand.execute(ReloadCommand.java:25)
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:141)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.dispatchCommand(CraftServer.java:645)
        at org.bukkit.craftbukkit.v1_9_R1.CraftServer.dispatchServerCommand(CraftServer.java:631)
        at net.minecraft.server.v1_9_R1.DedicatedServer.aL(DedicatedServer.java:438)
        at net.minecraft.server.v1_9_R1.DedicatedServer.D(DedicatedServer.java:401)
        at net.minecraft.server.v1_9_R1.MinecraftServer.C(MinecraftServer.java:660)
        at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:559)
        at java.lang.Thread.run(Thread.java:745)
=========================================
```