### PR TITLE
output.isEmpty()  NOT EQUALS null

### DIFF
--- a/src/skinsrestorer/shared/utils/MojangAPI.java
+++ b/src/skinsrestorer/shared/utils/MojangAPI.java
@@ -22,7 +22,7 @@ public class MojangAPI {
 		String idbeg = "\"uuid\":\"";
 		String idend = "\"}";
 
-			if (output.isEmpty() || output.contains("TooManyRequestsException")) {
+			if (output == null || output.isEmpty() || output.contains("TooManyRequestsException")) {
 				output = readURL(Config.ALT_UUID_URL + name).replace(" ", "");
 
 				idbeg = "\"uuid\":\"";


### PR DESCRIPTION
because
output.isEmpty()  NOT EQUALS null
and this api bug
(credits to Rise #0083) for reporting