### PR TITLE
Skull Crash Fix episode one

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -54,3 +54,6 @@ MySQL:
 Updater:
   Enabled: true
 #Enable or disable the updater check on enable.
+
+CrashSkullFix: false
+#Should SR attempt to prevent client crashes caused by broken skulls ?

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: SkinsRestorer
 main: skinsrestorer.bukkit.SkinsRestorer
-version: 12.8
+version: 12.8.1
 author: Blackfire62,Th3Tr0LLeR
 commands:
   skinsrestorer:

--- a/src/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/src/skinsrestorer/bukkit/SkinsRestorer.java
@@ -17,6 +17,10 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
@@ -24,6 +28,7 @@ import skinsrestorer.bukkit.commands.ClearCommand;
 import skinsrestorer.bukkit.commands.SkinCommand;
 import skinsrestorer.bukkit.commands.SrCommand;
 import skinsrestorer.bukkit.listeners.LoginListener;
+import skinsrestorer.bukkit.listeners.PacketListener;
 import skinsrestorer.bukkit.skinfactory.SkinFactory;
 import skinsrestorer.bukkit.skinfactory.UniversalSkinFactory;
 import skinsrestorer.shared.storage.Config;
@@ -47,6 +52,8 @@ public class SkinsRestorer extends JavaPlugin {
 	public void onEnable() {
 		instance = this;
 		final ConsoleCommandSender console = Bukkit.getConsoleSender();
+
+		PacketListener.injectForAll();
 
 		try {
 			Class.forName("net.minecraftforge.cauldron.CauldronHooks");
@@ -109,6 +116,17 @@ public class SkinsRestorer extends JavaPlugin {
 					});
 				}
 			});
+
+			if (Config.CRASHSKULLFIX) {
+				Bukkit.getPluginManager().registerEvents(new Listener() {
+
+					@EventHandler(priority = EventPriority.LOWEST)
+					public void onJoin(PlayerJoinEvent e) {
+						PacketListener.inject(e.getPlayer());
+					}
+
+				}, this);
+			}
 
 			if (Config.UPDATER_ENABLED) {
 				if (checkVersion().equals(getVersion())) {
@@ -212,6 +230,11 @@ public class SkinsRestorer extends JavaPlugin {
 
 		});
 
+	}
+
+	@Override
+	public void onDisable() {
+		PacketListener.uninjectForAll();
 	}
 
 	public static SkinsRestorer getInstance() {

--- a/src/skinsrestorer/bukkit/listeners/LoginListener.java
+++ b/src/skinsrestorer/bukkit/listeners/LoginListener.java
@@ -17,8 +17,10 @@ public class LoginListener implements Listener {
 
 	@EventHandler
 	public void onLogin(PlayerLoginEvent e) {
+
 		if (Config.DISABLE_ONJOIN_SKINS)
 			return;
+
 		Player p = e.getPlayer();
 
 		SkinsRestorer.getInstance().getFactory().applySkin(p, SkinStorage.getOrCreateSkinForPlayer(p.getName()));
@@ -26,6 +28,9 @@ public class LoginListener implements Listener {
 
 	@EventHandler
 	public void onJoin(final PlayerJoinEvent e) {
+		if (Config.CRASHSKULLFIX)
+			PacketListener.inject(e.getPlayer());
+
 		if (Config.DISABLE_ONJOIN_SKINS)
 			return;
 

--- a/src/skinsrestorer/bukkit/listeners/PacketListener.java
+++ b/src/skinsrestorer/bukkit/listeners/PacketListener.java
@@ -1,0 +1,109 @@
+package skinsrestorer.bukkit.listeners;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import skinsrestorer.shared.utils.ReflectionUtil;
+
+public class PacketListener extends ChannelDuplexHandler {
+
+	@SuppressWarnings("unused")
+	private Player p;
+	private Class<?> PlayOutTileEntityData;
+
+	public PacketListener(Player p) {
+		this.p = p;
+		try {
+			PlayOutTileEntityData = ReflectionUtil.getNMSClass("PacketPlayOutTileEntityData");
+		} catch (Exception e) {
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+		if (PlayOutTileEntityData.isInstance(msg)) {
+
+			Object tag = ReflectionUtil.getObject(msg, "c");
+			Object owner = ReflectionUtil.invokeMethod(tag.getClass(), tag, "getCompound",
+					new Class<?>[] { String.class }, "Owner");
+
+			if (!owner.toString().isEmpty()) {
+
+				Object props = ReflectionUtil.invokeMethod(owner.getClass(), owner, "getCompound",
+						new Class<?>[] { String.class }, "Properties");
+
+				if (!props.toString().isEmpty()) {
+
+					Map<String, Object> map = (Map<String, Object>) ReflectionUtil.getObject(props, "map");
+
+					for (Entry<String, Object> entry : map.entrySet()) {
+
+						if (!entry.getKey().equals("textures"))
+							continue;
+
+						String value = entry.getValue().toString();
+						if (value.contains("\"\"") || !value.contains("Value:\"")) {
+							return;
+						}
+					}
+
+				}
+			}
+
+		}
+
+		super.write(ctx, msg, promise);
+	}
+
+	public static void injectForAll() {
+		for (Player p : Bukkit.getOnlinePlayers())
+			inject(p);
+	}
+
+	public static void uninjectForAll() {
+		for (Player p : Bukkit.getOnlinePlayers())
+			uninject(p);
+	}
+
+	public static void inject(Player p) {
+		try {
+			Object craftOnline = ReflectionUtil.getBukkitClass("entity.CraftPlayer").cast(p);
+			Object craftHandle = ReflectionUtil.invokeMethod(craftOnline.getClass(), craftOnline, "getHandle");
+			Object playerCon = ReflectionUtil.getField(craftHandle.getClass(), "playerConnection").get(craftHandle);
+			Object manager = ReflectionUtil.getField(playerCon.getClass(), "networkManager").get(playerCon);
+			Channel channel = (Channel) ReflectionUtil.getField(manager.getClass(), "channel").get(manager);
+
+			if (channel.pipeline().context("PacketListener") != null)
+				channel.pipeline().remove("PacketListener");
+			// channel.pipeline().addBefore("packet_handler", "PacketListener",
+			// new PacketHandler(p));
+			channel.pipeline().addAfter("encoder", "PacketListener", new PacketListener(p));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void uninject(Player p) {
+		try {
+			Object craftOnline = ReflectionUtil.getBukkitClass("entity.CraftPlayer").cast(p);
+			Object craftHandle = ReflectionUtil.invokeMethod(craftOnline.getClass(), craftOnline, "getHandle");
+			Object playerCon = ReflectionUtil.getField(craftHandle.getClass(), "playerConnection").get(craftHandle);
+			Object manager = ReflectionUtil.getField(playerCon.getClass(), "networkManager").get(playerCon);
+			Channel channel = (Channel) ReflectionUtil.getField(manager.getClass(), "channel").get(manager);
+
+			if (channel.pipeline().context("PacketListener") != null)
+				channel.pipeline().remove("PacketListener");
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/src/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -168,7 +168,7 @@ public class UniversalSkinFactory implements SkinFactory {
 						new Class<?>[] { int.class, int.class, ItemStack }, player.getEntityId(), 3,
 						ReflectionUtil.invokeMethod(CraftItemStack, null, "asNMSCopy",
 								new Class<?>[] { ItemStack.class },
-								new Object[] { player.getInventory().getLeggings() }));
+								new Object[] { player.getInventory().getChestplate() }));
 
 				leggings = ReflectionUtil.invokeConstructor(PlayOutEntityEquipment,
 						new Class<?>[] { int.class, int.class, ItemStack }, player.getEntityId(), 2,

--- a/src/skinsrestorer/shared/storage/Config.java
+++ b/src/skinsrestorer/shared/storage/Config.java
@@ -37,6 +37,7 @@ public class Config {
 	public static String CUSTOMSKINS_CLIENTTOKEN = null;
 	public static boolean UPDATER_ENABLED = true;
 	public static boolean AUTOUPDATE = true;
+	public static boolean CRASHSKULLFIX = false;
 
 	public static void load(InputStream is) {
 		config.copyDefaults(is);
@@ -64,12 +65,19 @@ public class Config {
 
 		UPDATER_ENABLED = config.getBoolean("Updater.Enabled");
 
-		if (config.get("Updater.AutoUpdate") == null) {
-			config.set("Updater.AutoUpdate", false);
+		/*
+		 * if (config.get("Updater.AutoUpdate") == null) {
+		 * config.set("Updater.AutoUpdate", false); config.save(); }
+		 * 
+		 * AUTOUPDATE = config.getBoolean("Updater.AutoUpdate");
+		 */
+
+		if (config.get("CrashSkullFix") == null) {
+			config.set("CrashSkullFix", false);
 			config.save();
 		}
 
-		AUTOUPDATE = config.getBoolean("Updater.AutoUpdate");
+		CRASHSKULLFIX = config.getBoolean("CrashSkullFix");
 
 		DEFAULT_SKINS = config.getStringList("DefaultSkins.Names");
 		if (DEFAULT_SKINS == null || DEFAULT_SKINS.isEmpty()) {


### PR DESCRIPTION
There is your fix for client crashes caused by broken skulls which are
caused by shitty skull plugins.

TO ENABLE, SET "CrashSkullFix" IN YOUR CONFIG TO TRUE !

First beta release, should only work for 1.8+ servers because I cant be
bothered researching packet structures of previous versions. Tested on
1.10 , works on both BungeeMode and regular mode, so all you need to do
is just update all SkinsRestorers and your network will be p much skull
crash safe!

It does not fix the broken skulls just yet, it just prevents players
from receiving blank properties about the skull and crashing their game.
You can tell a skull is broken if it becomes grey, like skeleton like
grey but without the face.