### PR TITLE
FIX Warning MYSQL SSL CERT

### DIFF
--- a/src/skinsrestorer/shared/utils/MySQL.java
+++ b/src/skinsrestorer/shared/utils/MySQL.java
@@ -90,7 +90,7 @@ public class MySQL {
 				@Override
 				public void run() {
 					try {
-						con = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database,
+						con = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?verifyServerCertificate=false&useSSL=false",
 								username, password);
 						System.out.println("[SkinsRestorer] Connected to MySQL!");
 						createTable();


### PR DESCRIPTION
- Error on BungeeCord & Spigot using MySQL DB:
"For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification."

- I have changed this params for temporal fix:
"verifyServerCertificate" property is set to 'false'. 
"useSSL" property is set to 'false'.

You can add "useSSL" property to the config of plugin for user's use a SSL Cert.

Please update ASAP!
Thanks